### PR TITLE
fix: problemas de visualización en móvil (closes #9)

### DIFF
--- a/gh-pages/css/components.css
+++ b/gh-pages/css/components.css
@@ -250,3 +250,39 @@
     text-transform: uppercase;
     letter-spacing: 1px;
 }
+
+/* Mobile Adjustments */
+@media (max-width: 768px) {
+    .city-tabs {
+        flex-wrap: wrap;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-sm);
+    }
+
+    .city-tab {
+        flex: 1 1 auto;
+        text-align: center;
+        padding: var(--spacing-sm) var(--spacing-md);
+        font-size: 0.9em;
+    }
+
+    .btn {
+        padding: var(--spacing-md) var(--spacing-lg);
+        width: 100%;
+        text-align: center;
+        margin-bottom: var(--spacing-xs);
+    }
+
+    .btn-group {
+        flex-direction: column;
+        gap: var(--spacing-sm);
+    }
+
+    .prompt {
+        font-size: 0.9em;
+    }
+
+    .communities-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/gh-pages/css/layout.css
+++ b/gh-pages/css/layout.css
@@ -108,6 +108,11 @@ body::before {
         padding: var(--spacing-md);
     }
 
+    .terminal-header {
+        margin-bottom: var(--spacing-lg);
+        padding: var(--spacing-md);
+    }
+
     .terminal-title {
         font-size: 2em;
     }


### PR DESCRIPTION
## Descripción

Se corrige el problema donde las pestañas de ciudades se cortaban en dispositivos móviles. Se agregó `flex-wrap` y se ajustaron los padding/margins para mejorar la visualización en pantallas pequeñas.

## Tipo de Cambio

- [x] 🐛 Bug fix

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] He revisado mi propio código
- [x] Mis cambios no generan warnings nuevos

## Cómo se ha Probado

Se realizó una verificación visual simulando un dispositivo móvil (375x812). Las pestañas ahora se distribuyen en múltiples líneas cuando es necesario.

## Issues Relacionados

- Closes #9