### PR TITLE
feat: agregar utm_source=cron-quiles a enlaces de eventos

### DIFF
--- a/gh-pages/js/ui/Calendar.js
+++ b/gh-pages/js/ui/Calendar.js
@@ -7,6 +7,22 @@ import { appStore } from '../core/Store.js';
 import { DateUtils } from '../utils/dates.js';
 import { DOM } from '../utils/dom.js';
 
+/**
+ * Adds utm_source=cron-quiles to a URL for tracking outgoing links.
+ * @param {string} url - The original URL
+ * @returns {string} - URL with utm_source parameter added
+ */
+function addUtmSource(url) {
+    if (!url) return url;
+    try {
+        const urlObj = new URL(url);
+        urlObj.searchParams.set('utm_source', 'cron-quiles');
+        return urlObj.toString();
+    } catch {
+        return url;
+    }
+}
+
 export class Calendar {
     constructor(containerId) {
         this.container = document.getElementById(containerId);
@@ -247,7 +263,7 @@ export class Calendar {
         // Link Wrapper
         let titleContainer = DOM.create('div', { className: 'calendar-month-event-title' });
         if (event.url) {
-            const link = DOM.create('a', { attributes: { href: event.url, target: '_blank', rel: 'noopener' } });
+            const link = DOM.create('a', { attributes: { href: addUtmSource(event.url), target: '_blank', rel: 'noopener' } });
             if (typeof titleNode === 'string') link.textContent = titleNode;
             else link.appendChild(titleNode);
             titleContainer.appendChild(link);
@@ -285,7 +301,7 @@ export class Calendar {
                 className: 'event-link',
                 text: i18n.t('cal.viewEvent'),
                 attributes: {
-                    href: event.url,
+                    href: addUtmSource(event.url),
                     target: '_blank',
                     style: 'color: var(--terminal-green); margin-top: 5px; display: inline-block;'
                 }


### PR DESCRIPTION
## Resumen
- Agrega el parámetro `utm_source=cron-quiles` a todos los enlaces salientes de eventos
- Afecta tanto los enlaces del título del evento como los botones "Ver evento"
- Usa una función auxiliar con fallback para URLs inválidas

## Decisión pendiente

**Comportamiento actual:** La implementación **sobrescribe** cualquier `utm_source` existente en la URL original.

Por ejemplo:
- `https://eventbrite.com/e/123?utm_source=meetup` → `https://eventbrite.com/e/123?utm_source=cron-quiles`

**Alternativa:** Respetar el `utm_source` existente y solo agregar si no existe:

```javascript
if (!urlObj.searchParams.has('utm_source')) {
    urlObj.searchParams.set('utm_source', 'cron-quiles');
}
```

Queda a criterio del revisor cuál comportamiento es preferible.

## Plan de pruebas
- [ ] Verificar que los enlaces del título incluyen `?utm_source=cron-quiles`
- [ ] Verificar que los botones "Ver evento" incluyen el parámetro UTM
- [ ] Confirmar que URLs con parámetros existentes funcionan correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)